### PR TITLE
Bugfixes

### DIFF
--- a/.arduino-ci.yml
+++ b/.arduino-ci.yml
@@ -1,5 +1,6 @@
 compile:
   platforms:
+    - uno
     - nano_every
 
   libraries:
@@ -8,6 +9,7 @@ compile:
 
 unittest:
   platforms:
+    - uno
     - nano_every
 
 # nano_every definition isn't yet in a released arduino_ci version

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ namespace MasterPin {
 };
 ```
 
-Similarly, the information on the pin is a type of _signal_, and we need a `0`-based list of what signals are coming from the master board.  These will be a direct copy of the pin names, but in a different namespace:
+Similarly, the information on the pin is a type of _signal_, and we want to group together all our signals in a coherent way.  For this, we need a `0`-based list the signals.  These will be a direct copy of the pin names, but in a different namespace:
 
 ```c++
 namespace MasterSignal {
@@ -111,11 +111,14 @@ namespace MasterSignal {
 };
 ```
 
+The purpose of all this pedantry is to clue in the compiler as to what we are doing.  If we use the wrong value in a function call somewhere, it will generate a compiler warning for us -- in a way that using the raw integers would not.
+
+
 ### `DashMessage.h` - for defining the wire protocol
 
 This is the file that defines how `MasterSignal` values are packed and unpacked from bytes that flow across I2C.
 
-This file is necessary because more than 8 bits (as of this writing, 10) need to be transmitted, requiring multiple bytes to transmit any message.  One option would be to send 1 bit per message byte, with 7 bits to say what kind of info is being transmitted and 1 bit of information.  That's a lot of overhad.
+This file is necessary because more than 8 bits (as of this writing, 10) need to be transmitted, requiring multiple bytes to transmit any message.  One option would be to send 1 bit per message byte, with 7 bits to say what kind of info is being transmitted and 1 bit of information.  That's a lot of overhead.
 
 We can do a bit better by reserving bit positions in each byte for specific signal data, and (knowing the total message length ahead of time) processing a chain of those bytes at once.  All we need to know is where the message starts.
 
@@ -143,7 +146,7 @@ typedef struct DashMessage {
 The struct is generally used by the sender as follows
 
 ```c++
-  DashMessage d(digitalRead); // create a message from the current state of pins
+  DashMessage d(digitalRead); // create a message from the current state of pins -- using the digitalRead function
   d.send(Wire, SLAVE_I2C_ADDRESS);
 ```
 

--- a/examples/BinkyMasterDashHeadless/BinkyMasterDashHeadless.ino
+++ b/examples/BinkyMasterDashHeadless/BinkyMasterDashHeadless.ino
@@ -1,0 +1,49 @@
+/**
+ * Project Binky master dashboard program -- it just sends pin values to the slave board
+ */
+
+#include <Wire.h>
+#include <MasterProperties.h>
+#include <DashMessage.h>
+
+
+
+void setup() {
+  Wire.begin(); // I2C bus master -- no ID
+  Serial.begin(115200);
+}
+
+void loop() {
+
+  const unsigned long t_raw = millis();
+  const unsigned long t = t_raw % 10000;
+  const bool isBoostCritical = t > 9000;
+  const bool isBoostWarning  = !isBoostCritical && (t > 8000);
+
+  Serial.print("t_raw ");
+  Serial.print(t_raw);
+  Serial.print("\tt ");
+  Serial.print(t);
+  Serial.print("\t");
+  Serial.print(t > 3000 ? "O" : ".");
+  Serial.print(t > 4000 ? "O" : ".");
+  Serial.print(t > 5000 ? "O" : ".");
+  Serial.print(isBoostCritical ? "C" : (isBoostWarning ? "W" : "_"));
+  Serial.println();
+
+  DashMessage d;
+  d.setBit(MasterSignal::Values::boostWarning,         isBoostWarning);
+  d.setBit(MasterSignal::Values::boostCritical,        isBoostCritical);
+  d.setBit(MasterSignal::Values::acOn,                 t > 3000);
+  d.setBit(MasterSignal::Values::heatedRearWindowOn,   t > 4000);
+  d.setBit(MasterSignal::Values::hazardOff,            0);
+  d.setBit(MasterSignal::Values::rearFoggerOn,         t > 5000);
+  d.setBit(MasterSignal::Values::scrollCAN,            0);
+  d.setBit(MasterSignal::Values::scrollPresetColours,  0);
+  d.setBit(MasterSignal::Values::scrollRainbowEffects, 0 < (t % 5000) && (t % 5000) < 100);
+  d.setBit(MasterSignal::Values::scrollBrightness,     0);
+
+  d.send(Wire, SLAVE_I2C_ADDRESS);
+
+  delay(20); // not sure how often we need to send updates, but ~50 times per second is probably OK
+}

--- a/examples/BinkySlaveDash/BinkySlaveDash.ino
+++ b/examples/BinkySlaveDash/BinkySlaveDash.ino
@@ -13,13 +13,50 @@
 #include <DashMessage.h>
 #include <DashState.h>
 
+// work around a VERY ANNOYING PROBLEM with how arduino defines its internal functions
+#ifndef pin_size_t
+  void myPinMode(unsigned char pin, unsigned char mode) {
+    pinMode(pin, mode);
+  }
+
+  int myAnalogRead(unsigned char pin) {
+    return analogRead(pin);
+  }
+
+  int myDigitalRead(unsigned char pin) {
+    return digitalRead(pin);
+  }
+
+  void myDigitalWrite(unsigned char pin, int val) {
+    digitalWrite(pin, val);
+  }
+#else
+  void myPinMode(pin_size_t pin, pin_size_t mode) {
+    pinMode(pin, mode);
+  }
+
+  int myAnalogRead(pin_size_t pin) {
+    return analogRead(pin);
+  }
+
+  int myDigitalRead(pin_size_t pin) {
+    return digitalRead(pin);
+  }
+
+  void myDigitalWrite(pin_size_t pin, int val) {
+    digitalWrite(pin, val);
+  }
+#endif
+
+
+
 // This just provides all the library functions the DashState.h file will need.
 // Doing it this way allows us to swap in different functions for unit testing.
 DashSupport ds = {
-  pinMode,
-  analogRead,
-  digitalRead,
-  digitalWrite,
+  myPinMode,
+  myAnalogRead,
+  myDigitalRead,
+  myDigitalWrite,
   &FastLED
 };
 
@@ -38,14 +75,25 @@ void receiveDashMessage(int /* bytes */) {
 }
 
 void setup() {
+  // turn off any LEDs we aren't using
+  struct CRGB leds[64];
+  FastLED.addLeds<LED_TYPE, SlavePin::Values::ledStrip, COLOR_ORDER>(leds, 64).setCorrection(TypicalLEDStrip);
+  for (int i = 0; i < 64; ++i) leds[i] = CRGB::HTMLColorCode(CRGB::Black);
+  FastLED.show();
+
+  // serial debugging
+  // Serial.begin(1000000);
+
   dash.setup();
+
   Wire.begin(SLAVE_I2C_ADDRESS);      // Start the I2C Bus as Slave on address
   Wire.onReceive(receiveDashMessage); // Attach a function to trigger when something is received.
 }
 
 void loop() {
   const unsigned long currentMillis = millis();
-  SlaveState state(digitalRead, analogRead);
-  dash.setState(state);
+  dash.setSlaveState(myDigitalRead, myAnalogRead);
+
   dash.apply(currentMillis);
+  // Serial.println(dash.lastStateString(currentMillis));
 }

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Instrument panel driver for a certain horse
 category=Other
 url=https://github.com/ianfixes/ManeDisplay
 architectures=*
-includes=CalibratedServo.h,DashMessage.h,DashState.h,MasterProperties.h,SlaveProperties.h
+includes=CalibratedServo.h,Debouncer.h,DashMessage.h,DashState.h,MasterProperties.h,SlaveProperties.h

--- a/src/CalibratedServo.h
+++ b/src/CalibratedServo.h
@@ -1,5 +1,10 @@
 #pragma once
-#include <Servo.h>
+
+#ifndef ARDUINO_CI_COMPILATION_MOCKS
+  #include <Servo.h>
+#else
+  #include "FakeServo.h"
+#endif
 
 // A range defines a lower and upper bound
 typedef struct Range {

--- a/src/CalibratedServo.h
+++ b/src/CalibratedServo.h
@@ -6,7 +6,8 @@ typedef struct Range {
   unsigned int min;
   unsigned int max;
 
-  unsigned int clamp(unsigned int v) const { return constrain(v, min, max); }
+  inline unsigned int clamp(unsigned int v) const { return constrain(v, min, max); }
+  inline unsigned int midpoint() const { return  (max - min) / 2; }
 } Range;
 
 // a calibrated servo defines its input (signal) and output (position) ranges

--- a/src/DashMessage.h
+++ b/src/DashMessage.h
@@ -110,7 +110,7 @@ typedef struct DashMessage {
   }
 
   // read payload from digital input pins
-  void setFromPins(int (*myDigitalRead)(pin_size_t)) {
+  void setFromPins(PinStatus (*myDigitalRead)(pin_size_t)) {
     setBit(MasterSignal::Values::boostWarning,         myDigitalRead(MasterPin::Values::boostWarning        ));
     setBit(MasterSignal::Values::boostCritical,        myDigitalRead(MasterPin::Values::boostCritical       ));
     setBit(MasterSignal::Values::acOn,                 myDigitalRead(MasterPin::Values::acOn                ));
@@ -159,7 +159,7 @@ typedef struct DashMessage {
   }
 
   // construct from arduino inputs
-  DashMessage(int (*myDigitalRead)(pin_size_t)) {
+  DashMessage(PinStatus (*myDigitalRead)(pin_size_t)) {
     initFrames();
     setFromPins(myDigitalRead);
   }

--- a/src/DashMessage.h
+++ b/src/DashMessage.h
@@ -110,6 +110,21 @@ typedef struct DashMessage {
   }
 
   // read payload from digital input pins
+  void setFromPins(int (*myDigitalRead)(pin_size_t)) {
+    setBit(MasterSignal::Values::boostWarning,         myDigitalRead(MasterPin::Values::boostWarning        ));
+    setBit(MasterSignal::Values::boostCritical,        myDigitalRead(MasterPin::Values::boostCritical       ));
+    setBit(MasterSignal::Values::acOn,                 myDigitalRead(MasterPin::Values::acOn                ));
+    setBit(MasterSignal::Values::heatedRearWindowOn,   myDigitalRead(MasterPin::Values::heatedRearWindowOn  ));
+    setBit(MasterSignal::Values::hazardOff,            myDigitalRead(MasterPin::Values::hazardOff           ));
+    setBit(MasterSignal::Values::rearFoggerOn,         myDigitalRead(MasterPin::Values::rearFoggerOn        ));
+    setBit(MasterSignal::Values::scrollCAN,            myDigitalRead(MasterPin::Values::scrollCAN           ));
+    setBit(MasterSignal::Values::scrollPresetColours,  myDigitalRead(MasterPin::Values::scrollPresetColours ));
+    setBit(MasterSignal::Values::scrollRainbowEffects, myDigitalRead(MasterPin::Values::scrollRainbowEffects));
+    setBit(MasterSignal::Values::scrollBrightness,     myDigitalRead(MasterPin::Values::scrollBrightness    ));
+  }
+
+#ifdef PinStatus
+  // read payload from digital input pins
   void setFromPins(PinStatus (*myDigitalRead)(pin_size_t)) {
     setBit(MasterSignal::Values::boostWarning,         myDigitalRead(MasterPin::Values::boostWarning        ));
     setBit(MasterSignal::Values::boostCritical,        myDigitalRead(MasterPin::Values::boostCritical       ));
@@ -122,6 +137,7 @@ typedef struct DashMessage {
     setBit(MasterSignal::Values::scrollRainbowEffects, myDigitalRead(MasterPin::Values::scrollRainbowEffects));
     setBit(MasterSignal::Values::scrollBrightness,     myDigitalRead(MasterPin::Values::scrollBrightness    ));
   }
+#endif
 
   // read input from I2C
   void setFromWire(TwoWire &wire) {
@@ -159,10 +175,18 @@ typedef struct DashMessage {
   }
 
   // construct from arduino inputs
+  DashMessage(int (*myDigitalRead)(pin_size_t)) {
+    initFrames();
+    setFromPins(myDigitalRead);
+  }
+
+#ifdef PinStatus
+  // construct from arduino inputs
   DashMessage(PinStatus (*myDigitalRead)(pin_size_t)) {
     initFrames();
     setFromPins(myDigitalRead);
   }
+#endif
 
   // construct from the wire
   DashMessage(TwoWire wire) {

--- a/src/DashState.h
+++ b/src/DashState.h
@@ -91,7 +91,7 @@ const unsigned int NUM_DASH_LEDS = DASH_LED_MAX + 1;
 typedef struct DashSupport {
   void (*pinMode)(pin_size_t, int);
   int (*analogRead)(unsigned char);
-  int (*digitalRead)(unsigned char);
+  PinStatus (*digitalRead)(unsigned char);
   void (*digitalWrite)(pin_size_t, int);
   CFastLED* fastLed;
 } DashSupport;

--- a/src/DashState.h
+++ b/src/DashState.h
@@ -91,7 +91,11 @@ const unsigned int NUM_DASH_LEDS = DASH_LED_MAX + 1;
 typedef struct DashSupport {
   void (*pinMode)(pin_size_t, int);
   int (*analogRead)(unsigned char);
+#ifdef PinStatus
   PinStatus (*digitalRead)(unsigned char);
+#else
+  int (*digitalRead)(unsigned char);
+#endif
   void (*digitalWrite)(pin_size_t, int);
   CFastLED* fastLed;
 } DashSupport;

--- a/src/DashState.h
+++ b/src/DashState.h
@@ -3,7 +3,13 @@
 #include "DashMessage.h"
 #include "CalibratedServo.h"
 #include "LEDState.h"
-#include <FastLED.h>
+
+
+#ifndef ARDUINO_CI_COMPILATION_MOCKS
+  #include <FastLED.h>
+#else
+  #include "FakeFastLED.h"
+#endif
 
 /**
  * This file defines the dashboard LEDs state, servos, and how the dash performs its logic

--- a/src/DashState.h
+++ b/src/DashState.h
@@ -32,7 +32,7 @@ const Range oilServoLimit   { 0, 180 };
 
 // define limits for LED strip brightness
 const Range LEDStripBrightnessLimit { 5, 255 };
-const int dimBrightnessLevel = (LEDStripBrightnessLimit.max - LEDStripBrightnessLimit.min) / 2;
+const int dimBrightnessLevel = LEDStripBrightnessLimit.midpoint();
 
 const unsigned int ARDUINO_BOOT_ANIMATION_MS = 2000; // amount of time that we can use to do a bootup sequence
 const unsigned int ARDUINO_SOFT_SHUTDOWN_MS = 3000; // amount of time that we can use to do a soft shutdown

--- a/src/DashState.h
+++ b/src/DashState.h
@@ -95,13 +95,20 @@ const unsigned int NUM_DASH_LEDS = DASH_LED_MAX + 1;
 // This is a way to separate the function of these classes from the hardware,
 // which will make testing easier -- we can feed it mock functions if we want
 typedef struct DashSupport {
+#ifdef pin_size_t
   void (*pinMode)(pin_size_t, int);
+#else
+  void (*pinMode)(uint8_t, uint8_t);
+#endif
+
   int (*analogRead)(unsigned char);
+
 #ifdef PinStatus
   PinStatus (*digitalRead)(unsigned char);
 #else
   int (*digitalRead)(unsigned char);
 #endif
+
   void (*digitalWrite)(pin_size_t, int);
   CFastLED* fastLed;
 } DashSupport;
@@ -224,28 +231,6 @@ typedef struct DashState {
     new     IlluminationLED(leds, NUM_DASH_LEDS, DashLED::Values::windowSw0)
   };
 
-  // construct empty container
-  // This is also where we set the calibration data for the servos
-  DashState(DashSupport ds):
-    support(ds),
-    fuelGauge(SlavePin::Values::fuelServo, fuelSenderLimit, fuelServoLimit),
-    tempGauge(SlavePin::Values::tempServo, tempSenderLimit, tempServoLimit),
-    oilGauge( SlavePin::Values::oilServo,  oilSenderLimit,  oilServoLimit),
-    bootStartTime(0),
-    ignitionLastOnTime(0)
-  {}
-
-  // accept a message from I2C
-  void setMessage(DashMessage const &dm) {
-    nextState.setMasterSignals(dm);
-  }
-
-  // accept a hardware state
-  void setState(SlaveState state) {
-    state.masterMessage = nextState.masterMessage; // carry over current message state
-    nextState = state;
-  }
-
   // measure the time since the first measured time
   inline bool inBootSequence(unsigned long const &nMillis) const {
     return (nMillis - bootStartTime) < ARDUINO_BOOT_ANIMATION_MS;
@@ -291,6 +276,58 @@ typedef struct DashState {
     return (nMillis - ignitionLastOnTime) < ARDUINO_SOFT_SHUTDOWN_MS;
   }
 
+
+  // construct empty container
+  // This is also where we set the calibration data for the servos
+  DashState(DashSupport ds):
+    support(ds),
+    fuelGauge(SlavePin::Values::fuelServo, fuelSenderLimit, fuelServoLimit),
+    tempGauge(SlavePin::Values::tempServo, tempSenderLimit, tempServoLimit),
+    oilGauge( SlavePin::Values::oilServo,  oilSenderLimit,  oilServoLimit)
+  {}
+
+  // accept a message from I2C
+  void setMessage(DashMessage const &dm) {
+    nextState.setMasterSignals(dm);
+  }
+
+  inline SlaveState& state() {
+    return nextState;
+  }
+
+  // this is only for unit testing
+  inline SlaveState& getLastState() {
+    return lastState;
+  }
+
+  // accept a hardware state
+  void setState(SlaveState state) {
+    DashMessage d(nextState.masterMessage);
+    nextState = state;
+    nextState.masterMessage = d;
+  }
+
+  // accept a hardware state
+  void setSlaveState(int (*myDigitalRead)(pin_size_t), int (*myAnalogRead)(pin_size_t)) {
+    nextState.setFromPins(myDigitalRead, myAnalogRead);
+  }
+
+#ifdef PinStatus
+  // accept a hardware state
+  void setSlaveState(PinStatus (*myDigitalRead)(pin_size_t), int (*myAnalogRead)(pin_size_t)) {
+    nextState.setFromPins(myDigitalRead, myAnalogRead);
+  }
+#endif
+
+  // reset members (helpful for unit testing)
+  void reset() {
+    bootStartTime = 0;
+    ignitionLastOnTime = 0;
+    SlaveState newstate;
+    lastState = newstate;
+    nextState = newstate;
+  }
+
   // perform all hardware setup and software state init for this board
   void setup() {
     // configure inputs
@@ -304,6 +341,8 @@ typedef struct DashState {
     oilGauge.setup();
 
     support.fastLed->addLeds<LED_TYPE, SlavePin::Values::ledStrip, COLOR_ORDER>(leds, NUM_DASH_LEDS).setCorrection(TypicalLEDStrip);
+
+    reset();
   }
 
   // convert the dash state to something we can monitor
@@ -335,9 +374,9 @@ typedef struct DashState {
   // apply the internal state to the hardware
   void apply(unsigned long const &nMillis) {
     // DATA SAFETY SECTION: ensure state data isn't corrupted
+    nextState.debounce(nMillis);
     lastState = nextState; // try to keep the async 2wire receiver from interfering with current state
     if (0 == bootStartTime) bootStartTime = nMillis; // get a real measure of boot start time
-
 
     // TODO: delete the list when everything's crossed off it
     // here are the things we have to make sense of
@@ -353,10 +392,11 @@ typedef struct DashState {
       processShutdownSequence(nMillis);
       return;
     }
+    ignitionLastOnTime = nMillis;
 
     // STUFF ALLOWED DURING BOOT SECTION:
     // update the scroll CAN button state
-    support.digitalWrite(SlavePin::Values::scrollCAN, lastState.scrollCAN ? HIGH : LOW);
+    support.digitalWrite(SlavePin::Values::scrollCAN, lastState.scrollCANstate(nMillis) ? HIGH : LOW);
 
     // update all stateful LEDs from the input. this will mean they're always the right hue
     for (unsigned int i = DASH_LED_MIN; i < NUM_DASH_LEDS; ++i) {

--- a/src/Debouncer.h
+++ b/src/Debouncer.h
@@ -1,0 +1,56 @@
+#pragma once
+
+// This construct is about reducing the frequency of events -- we ignore some state changes
+// until we are sure they are stable.  This function will emit one event per stable state change
+// in the form of a trinary
+typedef struct Debouncer {
+
+  // we only care about the state changes
+  enum Event {
+    none   = 0,
+    toLow  = 1,
+    toHigh = 2,
+  };
+
+  unsigned int const stableTime;
+  unsigned long lastStableTime;  // the last time the state changed
+  bool stableState;
+  bool lastReading;
+  Event last;
+
+  Debouncer(unsigned int debounceDelay) :
+    stableTime(debounceDelay),
+    lastStableTime(0),
+    stableState(false),
+    lastReading(false),
+    last(Event::none)
+  {}
+
+  // force the debouncer into an initial state without generating an event
+  void force(bool desiredState) {
+    lastStableTime = 0;
+    stableState = desiredState;
+  }
+
+  // accept a new input value for debouncing
+  void process(unsigned long const &millis, bool reading) {
+    last = Event::none;                                    // default: nothing to see here
+    if (reading != lastReading) lastStableTime = millis;   // set "time since last changed"
+    if ((millis - lastStableTime) >= stableTime) {         // guard against recent changes
+      if (stableState != reading) {                        // detect changes
+        stableState = reading;                             // accept changes
+        last = stableState ? Event::toHigh : Event::toLow; // select event of change
+      }
+    }
+    lastReading = reading;                                 // prepare for next loop
+  }
+
+  // accept a new input value and return any event it generated
+  Event eventOf(unsigned long const &millis, bool reading) {
+    process(millis, reading);
+    return last;
+  }
+
+  private:
+    Debouncer(): stableTime(0) {}
+} Debouncer;

--- a/src/FakeFastLED.h
+++ b/src/FakeFastLED.h
@@ -1,0 +1,741 @@
+#pragma once
+
+struct CRGB;
+struct CHSV;
+
+// extern void hsv2rgb_rainbow( const CHSV& hsv, CRGB& rgb);
+
+
+struct CHSV {
+    union {
+        struct {
+            union {
+                uint8_t hue;
+                uint8_t h; };
+            union {
+                uint8_t saturation;
+                uint8_t sat;
+                uint8_t s; };
+            union {
+                uint8_t value;
+                uint8_t val;
+                uint8_t v; };
+        };
+        uint8_t raw[3];
+    };
+
+    inline CHSV() // __attribute__((always_inline))
+    {
+    }
+
+    inline CHSV( uint8_t ih, uint8_t is, uint8_t iv) // __attribute__((always_inline))
+        : h(ih), s(is), v(iv)
+    {
+    }
+
+    inline CHSV(const CHSV& rhs) // __attribute__((always_inline))
+    {
+        h = rhs.h;
+        s = rhs.s;
+        v = rhs.v;
+    }
+
+    inline CHSV& operator= (const CHSV& rhs) // __attribute__((always_inline))
+    {
+        h = rhs.h;
+        s = rhs.s;
+        v = rhs.v;
+        return *this;
+    }
+
+    inline CHSV& setHSV(uint8_t ih, uint8_t is, uint8_t iv) // __attribute__((always_inline))
+    {
+        h = ih;
+        s = is;
+        v = iv;
+        return *this;
+    }
+};
+
+typedef enum {
+    HUE_RED = 0,
+    HUE_ORANGE = 32,
+    HUE_YELLOW = 64,
+    HUE_GREEN = 96,
+    HUE_AQUA = 128,
+    HUE_BLUE = 160,
+    HUE_PURPLE = 192,
+    HUE_PINK = 224
+} HSVHue;
+
+struct CRGB {
+    union {
+        struct {
+            union {
+                uint8_t r;
+                uint8_t red;
+            };
+            union {
+                uint8_t g;
+                uint8_t green;
+            };
+            union {
+                uint8_t b;
+                uint8_t blue;
+            };
+        };
+        uint8_t raw[3];
+    };
+
+    inline uint8_t& operator[] (uint8_t x) // __attribute__((always_inline))
+    {
+        return raw[x];
+    }
+
+    inline const uint8_t& operator[] (uint8_t x) const // __attribute__((always_inline))
+    {
+        return raw[x];
+    }
+
+    // default values are UNINITIALIZED
+    inline CRGB() // __attribute__((always_inline))
+    {
+    }
+
+    inline CRGB( uint8_t ir, uint8_t ig, uint8_t ib)  // __attribute__((always_inline))
+        : r(ir), g(ig), b(ib)
+    {
+    }
+
+    inline CRGB( uint32_t colorcode)  // __attribute__((always_inline))
+    : r((colorcode >> 16) & 0xFF), g((colorcode >> 8) & 0xFF), b((colorcode >> 0) & 0xFF)
+    {
+    }
+
+    // inline CRGB( LEDColorCorrection colorcode) // __attribute__((always_inline))
+    // : r((colorcode >> 16) & 0xFF), g((colorcode >> 8) & 0xFF), b((colorcode >> 0) & 0xFF)
+    // {
+
+    // }
+
+    // inline CRGB( ColorTemperature colorcode) // __attribute__((always_inline))
+    // : r((colorcode >> 16) & 0xFF), g((colorcode >> 8) & 0xFF), b((colorcode >> 0) & 0xFF)
+    // {
+
+    // }
+
+    inline CRGB(const CRGB& rhs) // __attribute__((always_inline))
+    {
+        r = rhs.r;
+        g = rhs.g;
+        b = rhs.b;
+    }
+
+    // inline CRGB(const CHSV& rhs) // __attribute__((always_inline))
+    // {
+    //     hsv2rgb_rainbow( rhs, *this);
+    // }
+
+    inline CRGB& operator= (const CRGB& rhs) // __attribute__((always_inline))
+    {
+        r = rhs.r;
+        g = rhs.g;
+        b = rhs.b;
+        return *this;
+    }
+
+    inline CRGB& operator= (const uint32_t colorcode) // __attribute__((always_inline))
+    {
+        r = (colorcode >> 16) & 0xFF;
+        g = (colorcode >>  8) & 0xFF;
+        b = (colorcode >>  0) & 0xFF;
+        return *this;
+    }
+
+    inline CRGB& setRGB (uint8_t nr, uint8_t ng, uint8_t nb) // __attribute__((always_inline))
+    {
+        r = nr;
+        g = ng;
+        b = nb;
+        return *this;
+    }
+
+    // inline CRGB& setHSV (uint8_t hue, uint8_t sat, uint8_t val) // __attribute__((always_inline))
+    // {
+    //     hsv2rgb_rainbow( CHSV(hue, sat, val), *this);
+    //     return *this;
+    // }
+
+    // inline CRGB& setHue (uint8_t hue) // __attribute__((always_inline))
+    // {
+    //     hsv2rgb_rainbow( CHSV(hue, 255, 255), *this);
+    //     return *this;
+    // }
+
+    inline CRGB& operator= (const CHSV& rhs) // __attribute__((always_inline))
+    {
+        r = rhs.h;
+        g = rhs.s;
+        b = rhs.v;
+        return *this;
+    }
+
+    inline CRGB& setColorCode (uint32_t colorcode) // __attribute__((always_inline))
+    {
+        r = (colorcode >> 16) & 0xFF;
+        g = (colorcode >>  8) & 0xFF;
+        b = (colorcode >>  0) & 0xFF;
+        return *this;
+    }
+
+
+    // inline CRGB& operator+= (const CRGB& rhs )
+    // {
+    //     r = qadd8( r, rhs.r);
+    //     g = qadd8( g, rhs.g);
+    //     b = qadd8( b, rhs.b);
+    //     return *this;
+    // }
+
+    // inline CRGB& addToRGB (uint8_t d )
+    // {
+    //     r = qadd8( r, d);
+    //     g = qadd8( g, d);
+    //     b = qadd8( b, d);
+    //     return *this;
+    // }
+
+    // inline CRGB& operator-= (const CRGB& rhs )
+    // {
+    //     r = qsub8( r, rhs.r);
+    //     g = qsub8( g, rhs.g);
+    //     b = qsub8( b, rhs.b);
+    //     return *this;
+    // }
+
+    // inline CRGB& subtractFromRGB(uint8_t d )
+    // {
+    //     r = qsub8( r, d);
+    //     g = qsub8( g, d);
+    //     b = qsub8( b, d);
+    //     return *this;
+    // }
+
+    // inline CRGB& operator-- ()  // __attribute__((always_inline))
+    // {
+    //     subtractFromRGB(1);
+    //     return *this;
+    // }
+
+    // inline CRGB operator-- (int )  // __attribute__((always_inline))
+    // {
+    //     CRGB retval(*this);
+    //     --(*this);
+    //     return retval;
+    // }
+
+    // inline CRGB& operator++ ()  // __attribute__((always_inline))
+    // {
+    //     addToRGB(1);
+    //     return *this;
+    // }
+
+    // inline CRGB operator++ (int )  // __attribute__((always_inline))
+    // {
+    //     CRGB retval(*this);
+    //     ++(*this);
+    //     return retval;
+    // }
+
+    inline CRGB& operator/= (uint8_t d )
+    {
+        r /= d;
+        g /= d;
+        b /= d;
+        return *this;
+    }
+
+    inline CRGB& operator>>= (uint8_t d)
+    {
+      r >>= d;
+      g >>= d;
+      b >>= d;
+      return *this;
+    }
+
+    // inline CRGB& operator*= (uint8_t d )
+    // {
+    //     r = qmul8( r, d);
+    //     g = qmul8( g, d);
+    //     b = qmul8( b, d);
+    //     return *this;
+    // }
+
+    // inline CRGB& nscale8_video (uint8_t scaledown )
+    // {
+    //     nscale8x3_video( r, g, b, scaledown);
+    //     return *this;
+    // }
+
+    // inline CRGB& operator%= (uint8_t scaledown )
+    // {
+    //     nscale8x3_video( r, g, b, scaledown);
+    //     return *this;
+    // }
+
+    // inline CRGB& fadeLightBy (uint8_t fadefactor )
+    // {
+    //     nscale8x3_video( r, g, b, 255 - fadefactor);
+    //     return *this;
+    // }
+
+    // inline CRGB& nscale8 (uint8_t scaledown )
+    // {
+    //     nscale8x3( r, g, b, scaledown);
+    //     return *this;
+    // }
+
+    // inline CRGB& nscale8 (const CRGB & scaledown )
+    // {
+    //     r = ::scale8(r, scaledown.r);
+    //     g = ::scale8(g, scaledown.g);
+    //     b = ::scale8(b, scaledown.b);
+    //     return *this;
+    // }
+
+    // inline CRGB scale8 (const CRGB & scaledown ) const
+    // {
+    //     CRGB out;
+    //     out.r = ::scale8(r, scaledown.r);
+    //     out.g = ::scale8(g, scaledown.g);
+    //     out.b = ::scale8(b, scaledown.b);
+    //     return out;
+    // }
+
+    // inline CRGB& fadeToBlackBy (uint8_t fadefactor )
+    // {
+    //     nscale8x3( r, g, b, 255 - fadefactor);
+    //     return *this;
+    // }
+
+    inline CRGB& operator|= (const CRGB& rhs )
+    {
+        if( rhs.r > r) r = rhs.r;
+        if( rhs.g > g) g = rhs.g;
+        if( rhs.b > b) b = rhs.b;
+        return *this;
+    }
+
+    inline CRGB& operator|= (uint8_t d )
+    {
+        if( d > r) r = d;
+        if( d > g) g = d;
+        if( d > b) b = d;
+        return *this;
+    }
+
+    inline CRGB& operator&= (const CRGB& rhs )
+    {
+        if( rhs.r < r) r = rhs.r;
+        if( rhs.g < g) g = rhs.g;
+        if( rhs.b < b) b = rhs.b;
+        return *this;
+    }
+
+    inline CRGB& operator&= (uint8_t d )
+    {
+        if( d < r) r = d;
+        if( d < g) g = d;
+        if( d < b) b = d;
+        return *this;
+    }
+
+    inline operator bool() const // __attribute__((always_inline))
+    {
+        return r || g || b;
+    }
+
+    inline CRGB operator- ()
+    {
+        CRGB retval;
+        retval.r = 255 - r;
+        retval.g = 255 - g;
+        retval.b = 255 - b;
+        return retval;
+    }
+
+//     inline uint8_t getLuma ( )  const {
+//         //Y' = 0.2126 R' + 0.7152 G' + 0.0722 B'
+//         //     54            183       18 (!)
+
+//         uint8_t luma = scale8_LEAVING_R1_DIRTY( r, 54) + \
+//         scale8_LEAVING_R1_DIRTY( g, 183) + \
+//         scale8_LEAVING_R1_DIRTY( b, 18);
+//         cleanup_R1();
+//         return luma;
+//     }
+
+//     inline uint8_t getAverageLight( )  const {
+// #if FASTLED_SCALE8_FIXED == 1
+//         const uint8_t eightyfive = 85;
+// #else
+//         const uint8_t eightyfive = 86;
+// #endif
+//         uint8_t avg = scale8_LEAVING_R1_DIRTY( r, eightyfive) + \
+//         scale8_LEAVING_R1_DIRTY( g, eightyfive) + \
+//         scale8_LEAVING_R1_DIRTY( b, eightyfive);
+//         cleanup_R1();
+//         return avg;
+//     }
+
+    inline void maximizeBrightness( uint8_t limit = 255 )  {
+        uint8_t max = red;
+        if( green > max) max = green;
+        if( blue > max) max = blue;
+        uint16_t factor = ((uint16_t)(limit) * 256) / max;
+        red =   (red   * factor) / 256;
+        green = (green * factor) / 256;
+        blue =  (blue  * factor) / 256;
+    }
+
+    // inline uint8_t getParity()
+    // {
+    //     uint8_t sum = r + g + b;
+    //     return (sum & 0x01);
+    // }
+
+    // inline void setParity( uint8_t parity)
+    // {
+    //     uint8_t curparity = getParity();
+
+    //     if( parity == curparity) return;
+
+    //     if( parity ) {
+    //         // going 'up'
+    //         if( (b > 0) && (b < 255)) {
+    //             if( r == g && g == b) {
+    //                 r++;
+    //                 g++;
+    //             }
+    //             b++;
+    //         } else if( (r > 0) && (r < 255)) {
+    //             r++;
+    //         } else if( (g > 0) && (g < 255)) {
+    //             g++;
+    //         } else {
+    //             if( r == g && g == b) {
+    //                 r ^= 0x01;
+    //                 g ^= 0x01;
+    //             }
+    //             b ^= 0x01;
+    //         }
+    //     } else {
+    //         // going 'down'
+    //         if( b > 1) {
+    //             if( r == g && g == b) {
+    //                 r--;
+    //                 g--;
+    //             }
+    //             b--;
+    //         } else if( g > 1) {
+    //             g--;
+    //         } else if( r > 1) {
+    //             r--;
+    //         } else {
+    //             if( r == g && g == b) {
+    //                 r ^= 0x01;
+    //                 g ^= 0x01;
+    //             }
+    //             b ^= 0x01;
+    //         }
+    //     }
+    // }
+
+    typedef enum {
+        // AliceBlue=0xF0F8FF,
+        // Amethyst=0x9966CC,
+        // AntiqueWhite=0xFAEBD7,
+        // Aqua=0x00FFFF,
+        // Aquamarine=0x7FFFD4,
+        // Azure=0xF0FFFF,
+        // Beige=0xF5F5DC,
+        // Bisque=0xFFE4C4,
+        Black=0x000000,
+        // BlanchedAlmond=0xFFEBCD,
+        Blue=0x0000FF,
+        // BlueViolet=0x8A2BE2,
+        // Brown=0xA52A2A,
+        // BurlyWood=0xDEB887,
+        // CadetBlue=0x5F9EA0,
+        // Chartreuse=0x7FFF00,
+        // Chocolate=0xD2691E,
+        // Coral=0xFF7F50,
+        // CornflowerBlue=0x6495ED,
+        // Cornsilk=0xFFF8DC,
+        // Crimson=0xDC143C,
+        // Cyan=0x00FFFF,
+        // DarkBlue=0x00008B,
+        // DarkCyan=0x008B8B,
+        // DarkGoldenrod=0xB8860B,
+        // DarkGray=0xA9A9A9,
+        // DarkGrey=0xA9A9A9,
+        // DarkGreen=0x006400,
+        // DarkKhaki=0xBDB76B,
+        // DarkMagenta=0x8B008B,
+        // DarkOliveGreen=0x556B2F,
+        // DarkOrange=0xFF8C00,
+        // DarkOrchid=0x9932CC,
+        // DarkRed=0x8B0000,
+        // DarkSalmon=0xE9967A,
+        // DarkSeaGreen=0x8FBC8F,
+        // DarkSlateBlue=0x483D8B,
+        // DarkSlateGray=0x2F4F4F,
+        // DarkSlateGrey=0x2F4F4F,
+        // DarkTurquoise=0x00CED1,
+        // DarkViolet=0x9400D3,
+        // DeepPink=0xFF1493,
+        // DeepSkyBlue=0x00BFFF,
+        // DimGray=0x696969,
+        // DimGrey=0x696969,
+        // DodgerBlue=0x1E90FF,
+        // FireBrick=0xB22222,
+        // FloralWhite=0xFFFAF0,
+        // ForestGreen=0x228B22,
+        // Fuchsia=0xFF00FF,
+        // Gainsboro=0xDCDCDC,
+        // GhostWhite=0xF8F8FF,
+        // Gold=0xFFD700,
+        // Goldenrod=0xDAA520,
+        // Gray=0x808080,
+        // Grey=0x808080,
+        // Green=0x008000,
+        // GreenYellow=0xADFF2F,
+        // Honeydew=0xF0FFF0,
+        // HotPink=0xFF69B4,
+        // IndianRed=0xCD5C5C,
+        // Indigo=0x4B0082,
+        // Ivory=0xFFFFF0,
+        // Khaki=0xF0E68C,
+        // Lavender=0xE6E6FA,
+        // LavenderBlush=0xFFF0F5,
+        // LawnGreen=0x7CFC00,
+        // LemonChiffon=0xFFFACD,
+        // LightBlue=0xADD8E6,
+        // LightCoral=0xF08080,
+        // LightCyan=0xE0FFFF,
+        // LightGoldenrodYellow=0xFAFAD2,
+        // LightGreen=0x90EE90,
+        // LightGrey=0xD3D3D3,
+        // LightPink=0xFFB6C1,
+        // LightSalmon=0xFFA07A,
+        // LightSeaGreen=0x20B2AA,
+        // LightSkyBlue=0x87CEFA,
+        // LightSlateGray=0x778899,
+        // LightSlateGrey=0x778899,
+        // LightSteelBlue=0xB0C4DE,
+        // LightYellow=0xFFFFE0,
+        // Lime=0x00FF00,
+        // LimeGreen=0x32CD32,
+        // Linen=0xFAF0E6,
+        // Magenta=0xFF00FF,
+        // Maroon=0x800000,
+        // MediumAquamarine=0x66CDAA,
+        // MediumBlue=0x0000CD,
+        // MediumOrchid=0xBA55D3,
+        // MediumPurple=0x9370DB,
+        // MediumSeaGreen=0x3CB371,
+        // MediumSlateBlue=0x7B68EE,
+        // MediumSpringGreen=0x00FA9A,
+        // MediumTurquoise=0x48D1CC,
+        // MediumVioletRed=0xC71585,
+        // MidnightBlue=0x191970,
+        // MintCream=0xF5FFFA,
+        // MistyRose=0xFFE4E1,
+        // Moccasin=0xFFE4B5,
+        // NavajoWhite=0xFFDEAD,
+        // Navy=0x000080,
+        // OldLace=0xFDF5E6,
+        // Olive=0x808000,
+        // OliveDrab=0x6B8E23,
+        // Orange=0xFFA500,
+        // OrangeRed=0xFF4500,
+        // Orchid=0xDA70D6,
+        // PaleGoldenrod=0xEEE8AA,
+        // PaleGreen=0x98FB98,
+        // PaleTurquoise=0xAFEEEE,
+        // PaleVioletRed=0xDB7093,
+        // PapayaWhip=0xFFEFD5,
+        // PeachPuff=0xFFDAB9,
+        // Peru=0xCD853F,
+        // Pink=0xFFC0CB,
+        // Plaid=0xCC5533,
+        // Plum=0xDDA0DD,
+        // PowderBlue=0xB0E0E6,
+        // Purple=0x800080,
+        Red=0xFF0000,
+        // RosyBrown=0xBC8F8F,
+        // RoyalBlue=0x4169E1,
+        // SaddleBrown=0x8B4513,
+        // Salmon=0xFA8072,
+        // SandyBrown=0xF4A460,
+        // SeaGreen=0x2E8B57,
+        // Seashell=0xFFF5EE,
+        // Sienna=0xA0522D,
+        // Silver=0xC0C0C0,
+        // SkyBlue=0x87CEEB,
+        // SlateBlue=0x6A5ACD,
+        // SlateGray=0x708090,
+        // SlateGrey=0x708090,
+        // Snow=0xFFFAFA,
+        // SpringGreen=0x00FF7F,
+        // SteelBlue=0x4682B4,
+        // Tan=0xD2B48C,
+        // Teal=0x008080,
+        // Thistle=0xD8BFD8,
+        // Tomato=0xFF6347,
+        // Turquoise=0x40E0D0,
+        // Violet=0xEE82EE,
+        // Wheat=0xF5DEB3,
+        White=0xFFFFFF,
+        // WhiteSmoke=0xF5F5F5,
+        Yellow=0xFFFF00,
+        // YellowGreen=0x9ACD32,
+
+        // LED RGB color that roughly approximates
+        // the color of incandescent fairy lights,
+        // assuming that you're using FastLED
+        // color correction on your LEDs (recommended).
+        FairyLight=0xFFE42D,
+        // If you are using no color correction, use this
+        FairyLightNCC=0xFF9D2A
+
+    } HTMLColorCode;
+};
+
+
+inline __attribute__((always_inline)) bool operator== (const CRGB& lhs, const CRGB& rhs)
+{
+    return (lhs.r == rhs.r) && (lhs.g == rhs.g) && (lhs.b == rhs.b);
+}
+
+inline __attribute__((always_inline)) bool operator!= (const CRGB& lhs, const CRGB& rhs)
+{
+    return !(lhs == rhs);
+}
+
+inline __attribute__((always_inline)) bool operator< (const CRGB& lhs, const CRGB& rhs)
+{
+    uint16_t sl, sr;
+    sl = lhs.r + lhs.g + lhs.b;
+    sr = rhs.r + rhs.g + rhs.b;
+    return sl < sr;
+}
+
+inline __attribute__((always_inline)) bool operator> (const CRGB& lhs, const CRGB& rhs)
+{
+    uint16_t sl, sr;
+    sl = lhs.r + lhs.g + lhs.b;
+    sr = rhs.r + rhs.g + rhs.b;
+    return sl > sr;
+}
+
+inline __attribute__((always_inline)) bool operator>= (const CRGB& lhs, const CRGB& rhs)
+{
+    uint16_t sl, sr;
+    sl = lhs.r + lhs.g + lhs.b;
+    sr = rhs.r + rhs.g + rhs.b;
+    return sl >= sr;
+}
+
+inline __attribute__((always_inline)) bool operator<= (const CRGB& lhs, const CRGB& rhs)
+{
+    uint16_t sl, sr;
+    sl = lhs.r + lhs.g + lhs.b;
+    sr = rhs.r + rhs.g + rhs.b;
+    return sl <= sr;
+}
+
+
+// __attribute__((always_inline))
+// inline CRGB operator+( const CRGB& p1, const CRGB& p2)
+// {
+//     return CRGB( qadd8( p1.r, p2.r),
+//                  qadd8( p1.g, p2.g),
+//                  qadd8( p1.b, p2.b));
+// }
+
+// __attribute__((always_inline))
+// inline CRGB operator-( const CRGB& p1, const CRGB& p2)
+// {
+//     return CRGB( qsub8( p1.r, p2.r),
+//                  qsub8( p1.g, p2.g),
+//                  qsub8( p1.b, p2.b));
+// }
+
+// __attribute__((always_inline))
+// inline CRGB operator*( const CRGB& p1, uint8_t d)
+// {
+//     return CRGB( qmul8( p1.r, d),
+//                  qmul8( p1.g, d),
+//                  qmul8( p1.b, d));
+// }
+
+// __attribute__((always_inline))
+inline CRGB operator/( const CRGB& p1, uint8_t d)
+{
+    return CRGB( p1.r/d, p1.g/d, p1.b/d);
+}
+
+
+// __attribute__((always_inline))
+inline CRGB operator&( const CRGB& p1, const CRGB& p2)
+{
+    return CRGB( p1.r < p2.r ? p1.r : p2.r,
+                 p1.g < p2.g ? p1.g : p2.g,
+                 p1.b < p2.b ? p1.b : p2.b);
+}
+
+// __attribute__((always_inline))
+inline CRGB operator|( const CRGB& p1, const CRGB& p2)
+{
+    return CRGB( p1.r > p2.r ? p1.r : p2.r,
+                 p1.g > p2.g ? p1.g : p2.g,
+                 p1.b > p2.b ? p1.b : p2.b);
+}
+
+// __attribute__((always_inline))
+// inline CRGB operator%( const CRGB& p1, uint8_t d)
+// {
+//     CRGB retval( p1);
+//     retval.nscale8_video( d);
+//     return retval;
+// }
+
+
+
+enum EOrder {
+    RGB=0012,
+    RBG=0021,
+    GRB=0102,
+    GBR=0120,
+    BRG=0201,
+    BGR=0210
+};
+
+struct CHSV rgb2hsv_approximate(struct CRGB rgb) { return CHSV(rgb.r, rgb.g, rgb.b); }
+
+#define TypicalLEDStrip 333
+typedef bool WS2812B;
+
+typedef struct CFastLED {
+  int brightness;
+
+  CFastLED setBrightness(int b) { brightness = b; return *this; }
+  CFastLED setCorrection(int) { return *this; }
+
+  void show() {};
+
+  template<typename T1, uint8_t T2, EOrder T3>
+  CFastLED addLeds(struct CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) { return *this; }
+
+} CFastLED;

--- a/src/FakeServo.h
+++ b/src/FakeServo.h
@@ -1,0 +1,9 @@
+#pragma once
+
+typedef struct Servo {
+  int pin;
+  int pos;
+
+  void attach(int p) { pin = p; }
+  void write(int p) { pos = p; }
+} Servo;

--- a/src/LEDState.h
+++ b/src/LEDState.h
@@ -1,7 +1,12 @@
 #pragma once
 
 #include "SlaveProperties.h"
-#include <FastLED.h>
+
+#ifndef ARDUINO_CI_COMPILATION_MOCKS
+  #include <FastLED.h>
+#else
+  #include <FakeFastLED.h>
+#endif
 
 // Stateful LED behaviors
 //

--- a/src/LEDState.h
+++ b/src/LEDState.h
@@ -322,7 +322,9 @@ public:
   }
 };
 
-class BlinkingLED : public StatefulLED {
+
+// This class defines a blinking LED that can blink 2 different colors
+class MultiBlinkingLED : public StatefulLED {
 public:
   RainbowState    m_stRainbow;
   SolidColorState m_stSolid;
@@ -334,7 +336,7 @@ public:
   // note that even though the quiet states and the solid states are the same color,
   // the solid state can be interrupted at any time
 
-  BlinkingLED(struct CRGB* leds, int numLEDs, int index) :
+  MultiBlinkingLED(struct CRGB* leds, int numLEDs, int index) :
     StatefulLED(leds, numLEDs, index),
     m_stRainbow(numLEDs, index),
     m_stSolid(COLOR_WHITE),
@@ -382,9 +384,9 @@ public:
 
 };
 
-class BoostLED : public BlinkingLED {
+class BoostLED : public MultiBlinkingLED {
 public:
-  BoostLED(struct CRGB* leds, int numLEDs, int index) : BlinkingLED(leds, numLEDs, index) {}
+  BoostLED(struct CRGB* leds, int numLEDs, int index) : MultiBlinkingLED(leds, numLEDs, index) {}
 
   // string representation of the state name
   inline virtual String name() const { return "Bst"; };
@@ -397,9 +399,9 @@ public:
   }
 };
 
-class TachLED : public BlinkingLED {
+class TachLED : public MultiBlinkingLED {
 public:
-  TachLED(struct CRGB* leds, int numLEDs, int index) : BlinkingLED(leds, numLEDs, index) {}
+  TachLED(struct CRGB* leds, int numLEDs, int index) : MultiBlinkingLED(leds, numLEDs, index) {}
 
   // string representation of the state name
   inline virtual String name() const { return "Tach"; };

--- a/src/LEDState.h
+++ b/src/LEDState.h
@@ -245,9 +245,6 @@ public:
     SimpleLED(leds, numLEDs, index, rgb2hsv_approximate(color))
   {}
 
-  // string representation of the state name
-  inline virtual String name() const { return "Simple"; };
-
   // the master signal for rainbow mode overrides all others
   virtual LEDState* chooseNextState(unsigned long const &millis, const SlaveState &slave) {
     if (slave.getMasterSignal(MasterSignal::Values::scrollRainbowEffects)) {
@@ -326,7 +323,6 @@ public:
 // This class defines a blinking LED that can blink 2 different colors
 class MultiBlinkingLED : public StatefulLED {
 public:
-  RainbowState    m_stRainbow;
   SolidColorState m_stSolid;
   FlashLoudState  m_stFlashRedLoud;
   FlashQuietState m_stFlashRedQuiet;
@@ -338,16 +334,12 @@ public:
 
   MultiBlinkingLED(struct CRGB* leds, int numLEDs, int index) :
     StatefulLED(leds, numLEDs, index),
-    m_stRainbow(numLEDs, index),
     m_stSolid(COLOR_WHITE),
     m_stFlashRedLoud(COLOR_RED),
     m_stFlashRedQuiet(m_stSolid),
     m_stFlashAmberLoud(COLOR_AMBER),
     m_stFlashAmberQuiet(m_stSolid)
   {}
-
-  // string representation of the state name
-  inline virtual String name() const { return "Blinkn"; };
 
   // conditionally seed the flash states' timing
   void seedFlashTiming(unsigned long const &millis) {

--- a/src/LEDState.h
+++ b/src/LEDState.h
@@ -73,12 +73,12 @@ public:
 
   // the state just applies the saved color.
   // TODO: we could consider rapidly fading toward this color from whatever color was currently being displayed
-  virtual void loop(struct CRGB* led, unsigned long const & /* millis */) {
+  virtual void loop(struct CRGB* led, unsigned long const & /* millis */) override {
     *led = m_color; // TODO: see if there's a FastLED method for doing this more natively
   }
 
   // The state data
-  virtual String toStringWithParams(unsigned long const & /* millis */) const {
+  virtual String toStringWithParams(unsigned long const & /* millis */) const override {
     char ret[12];
     sprintf(ret, "Sld %02X%02X%02X", m_color.h, m_color.s, m_color.v);
     return String(ret);
@@ -118,7 +118,7 @@ public:
   virtual bool activeOnFirstHalf() const = 0;
 
   // The state data
-  virtual String toStringWithParams(unsigned long const & /* millis */) const {
+  virtual String toStringWithParams(unsigned long const & /* millis */) const override {
     char ret[12];
     sprintf(ret, "Fl%c %02X%02X%02X", (activeOnFirstHalf() ? '1' : '2'), m_color.h, m_color.s, m_color.v);
     return String(ret);
@@ -163,7 +163,7 @@ public:
   }
 
   // The state data
-  virtual String toStringWithParams(unsigned long const & millis) const {
+  virtual String toStringWithParams(unsigned long const & millis) const override {
     char ret[12];
     sprintf(ret, "Rnb    %03d", hue(millis));
     return String(ret);
@@ -292,7 +292,7 @@ public:
   IlluminationLED(struct CRGB* leds, int numLEDs, int index) : SimpleLED(leds, numLEDs, index, COLOR_WHITE) {}
 
   // string representation of the state name
-  inline virtual String name() const { return "Illu"; };
+  inline virtual String name() const override { return "Illu"; };
 };
 
 // control of the AC LED
@@ -301,7 +301,7 @@ public:
   AirCondLED(struct CRGB* leds, int numLEDs, int index) : SimpleLED(leds, numLEDs, index, COLOR_BLUE) {}
 
   // string representation of the state name
-  inline virtual String name() const { return "AC"; };
+  inline virtual String name() const override { return "AC"; };
 
   virtual bool isOn(unsigned long const & /* millis */, const SlaveState &slave) override {
     return slave.getMasterSignal(MasterSignal::Values::acOn);
@@ -314,7 +314,7 @@ public:
   HeatedRearWindowLED(struct CRGB* leds, int numLEDs, int index) : SimpleLED(leds, numLEDs, index, COLOR_YELLOW) {}
 
   // string representation of the state name
-  inline virtual String name() const { return "Hrw"; };
+  inline virtual String name() const override { return "Hrw"; };
 
   virtual bool isOn(unsigned long const & /* millis */, const SlaveState &slave) override {
     return slave.getMasterSignal(MasterSignal::Values::heatedRearWindowOn);
@@ -327,7 +327,7 @@ public:
   HazardLED(struct CRGB* leds, int numLEDs, int index) : SimpleLED(leds, numLEDs, index, COLOR_WHITE) {}
 
   // string representation of the state name
-  inline virtual String name() const { return "Haz"; };
+  inline virtual String name() const override { return "Haz"; };
 
   virtual bool isOn(unsigned long const & /* millis */, const SlaveState &slave) override {
     return !slave.getMasterSignal(MasterSignal::Values::hazardOff);
@@ -340,7 +340,7 @@ public:
   RearFoggerLED(struct CRGB* leds, int numLEDs, int index) : SimpleLED(leds, numLEDs, index, COLOR_AMBER) {}
 
   // string representation of the state name
-  inline virtual String name() const { return "Fog"; };
+  inline virtual String name() const override { return "Fog"; };
 
   virtual bool isOn(unsigned long const & /* millis */, const SlaveState &slave) override {
     return slave.getMasterSignal(MasterSignal::Values::rearFoggerOn);
@@ -407,7 +407,7 @@ public:
   BoostLED(struct CRGB* leds, int numLEDs, int index) : MultiBlinkingLED(leds, numLEDs, index) {}
 
   // string representation of the state name
-  inline virtual String name() const { return "Bst"; };
+  inline virtual String name() const override { return "Bst"; };
 
   virtual bool isWarning(const SlaveState &slave) const override {
     return slave.getMasterSignal(MasterSignal::Values::boostWarning);
@@ -422,7 +422,7 @@ public:
   TachLED(struct CRGB* leds, int numLEDs, int index) : MultiBlinkingLED(leds, numLEDs, index) {}
 
   // string representation of the state name
-  inline virtual String name() const { return "Tach"; };
+  inline virtual String name() const override { return "Tach"; };
 
   virtual bool isWarning(const SlaveState &slave) const override {
     return slave.tachometerWarning;

--- a/src/SlaveProperties.h
+++ b/src/SlaveProperties.h
@@ -1,6 +1,53 @@
 #pragma once
 #include <Arduino.h>
 #include "DashMessage.h"
+#include "Debouncer.h"
+
+unsigned int const DEBOUNCE_TIME_MS = 50;
+unsigned int const SCROLLCAN_PULSE_TIME = 50; // The duration of the HIGH signal to output when scrolling CAN
+
+// we may define a bunch of rainbow modes, and here is how we keep track of them
+typedef struct EffectMode {
+  enum Values {
+    none    = 0,
+    rainbow = 1,
+    sparkle = 2,
+  };
+
+  Values state;
+
+  EffectMode() {
+    state = none;
+  }
+
+  EffectMode(Values v) {
+    state = v;
+  }
+
+  inline int maxValue() const {
+    return Values::sparkle;
+  }
+
+  inline int isEffect() const {
+    return state != Values::none;
+  }
+
+  inline void next() {
+    if (state >= maxValue()) {
+      state = Values::none;
+    } else {
+      state = (Values)((int)state + 1);
+    }
+  }
+
+  // select the next mode, effect modes only
+  inline void nextEffect() {
+    do {
+      next();
+    } while (!isEffect());
+  }
+
+} EffectMode;
 
 /**
  * This file defines some of the properties of the slave board
@@ -31,7 +78,6 @@ namespace SlavePin {
 // This struct is responsible for all of the reading and bookkeeping of
 // the information that the slave board can collect
 typedef struct SlaveState {
-  bool scrollCAN;
   bool backlightDim;
   bool tachometerCritical;
   bool tachometerWarning;
@@ -42,6 +88,15 @@ typedef struct SlaveState {
   int oilPressureLevel;
 
   DashMessage masterMessage;
+
+  Debouncer CANEvent;
+  Debouncer colorEvent;
+  Debouncer effectsEvent;     //TODO: mark private
+  Debouncer brightnessEvent;
+
+  unsigned long CANPulseBegin; // the time at which a CAN pulse should start
+
+  EffectMode effectmode;
 
   // set the master signals
   inline void setMasterSignals(DashMessage const &m) {
@@ -58,10 +113,10 @@ typedef struct SlaveState {
     return masterMessage.getBit(position);
   }
 
+
   // Best if we keep the necessary setup for all the pins in this class,
   // since it needs to agree with the code that reads from those pins
-  static void setup(void (*myPinMode)(pin_size_t, int)) {
-    myPinMode(SlavePin::Values::scrollCAN,          INPUT);
+  static void setup(void (*myPinMode)(uint8_t, uint8_t)) {
     myPinMode(SlavePin::Values::backlightDim,       INPUT);
     myPinMode(SlavePin::Values::tachometerCritical, INPUT);
     myPinMode(SlavePin::Values::tachometerWarning,  INPUT);
@@ -71,9 +126,23 @@ typedef struct SlaveState {
     myPinMode(SlavePin::Values::ignitionInput,      INPUT);
   }
 
+
+#ifdef pin_size_t
+  // Best if we keep the necessary setup for all the pins in this class,
+  // since it needs to agree with the code that reads from those pins
+  static void setup(void (*myPinMode)(pin_size_t, int)) {
+    myPinMode(SlavePin::Values::backlightDim,       INPUT);
+    myPinMode(SlavePin::Values::tachometerCritical, INPUT);
+    myPinMode(SlavePin::Values::tachometerWarning,  INPUT);
+    myPinMode(SlavePin::Values::fuelInput,          INPUT);
+    myPinMode(SlavePin::Values::temperatureInput,   INPUT);
+    myPinMode(SlavePin::Values::oilInput,           INPUT);
+    myPinMode(SlavePin::Values::ignitionInput,      INPUT);
+  }
+#endif
+
   // read payload from digital input pins into the fields of this struct
-  void setFromPins(PinStatus (*myDigitalRead)(pin_size_t), int (*myAnalogRead)(pin_size_t)) {
-    scrollCAN          = myDigitalRead(SlavePin::Values::scrollCAN);
+  void setFromPins(int (*myDigitalRead)(pin_size_t), int (*myAnalogRead)(pin_size_t)) {
     backlightDim       = myDigitalRead(SlavePin::Values::backlightDim);
     tachometerCritical = myDigitalRead(SlavePin::Values::tachometerCritical);
     tachometerWarning  = myDigitalRead(SlavePin::Values::tachometerWarning);
@@ -84,13 +153,65 @@ typedef struct SlaveState {
     oilPressureLevel = myAnalogRead(SlavePin::Values::oilInput);
   }
 
+#ifdef PinStatus
+  // read payload from digital input pins into the fields of this struct
+  void setFromPins(PinStatus (*myDigitalRead)(pin_size_t), int (*myAnalogRead)(pin_size_t)) {
+    backlightDim       = myDigitalRead(SlavePin::Values::backlightDim);
+    tachometerCritical = myDigitalRead(SlavePin::Values::tachometerCritical);
+    tachometerWarning  = myDigitalRead(SlavePin::Values::tachometerWarning);
+    ignition           = myDigitalRead(SlavePin::Values::ignitionInput);
+
+    fuelLevel        = myAnalogRead(SlavePin::Values::fuelInput);
+    temperatureLevel = myAnalogRead(SlavePin::Values::temperatureInput);
+    oilPressureLevel = myAnalogRead(SlavePin::Values::oilInput);
+  }
+#endif
+
+  void debounce(unsigned long const &millis) {
+    // TODO: convert these into eventOf things
+    CANEvent.process(millis, masterMessage.getBit(MasterSignal::Values::scrollCAN));
+    colorEvent.process(millis, masterMessage.getBit(MasterSignal::Values::scrollPresetColours));
+    brightnessEvent.process(millis, masterMessage.getBit(MasterSignal::Values::scrollBrightness));
+
+    if (Debouncer::Event::toHigh == CANEvent.eventOf(millis, masterMessage.getBit(MasterSignal::Values::scrollCAN))) {
+      CANPulseBegin = millis;
+    }
+
+    if (Debouncer::Event::toHigh == effectsEvent.eventOf(millis, masterMessage.getBit(MasterSignal::Values::scrollRainbowEffects))) {
+      effectmode.next();
+    }
+  }
+
+  // whether the signal to scroll CAN should be high
+  bool scrollCANstate(unsigned long const &millis) {
+    return SCROLLCAN_PULSE_TIME < millis // don't pulse when the car is first turned on
+      && CANPulseBegin <= millis         // do pulse if we should start pulsing
+      && millis < (CANPulseBegin + SCROLLCAN_PULSE_TIME); // stop pulse after it expires
+  }
+
   // make a binary representation of what's in the message
   String toString() const {
     String ret = "";
     ret.concat(ignition           ? "I" : "i");
     ret.concat(backlightDim       ? "b" : "B");
-    ret.concat(scrollCAN          ? "S" : "s");
     ret.concat(tachometerCritical ? "C" : (tachometerWarning ? "W" : "_"));
+
+    ret.concat(" ");
+    if (effectsEvent.last == Debouncer::Event::none) {
+      ret.concat("_");
+    } else if (effectsEvent.last == Debouncer::Event::toLow) {
+      ret.concat("v");
+    } else if (effectsEvent.last == Debouncer::Event::toHigh) {
+      ret.concat("/");
+    }
+    ret.concat(" ");
+    if (effectmode.state == EffectMode::Values::none) {
+      ret.concat("N");
+    } else if (effectmode.state == EffectMode::Values::rainbow) {
+      ret.concat("R");
+    } else if (effectmode.state == EffectMode::Values::sparkle) {
+      ret.concat("S");
+    }
     ret.concat("\t");
 
     char buf[16];
@@ -100,13 +221,58 @@ typedef struct SlaveState {
     return ret;
   }
 
+  // default constructor: assign the debounce times. this means we need to define all other
+  // constructors and assignment operators
+  SlaveState() :
+    backlightDim(0),
+    tachometerCritical(0),
+    tachometerWarning(0),
+    ignition(0),
+    fuelLevel(0),
+    temperatureLevel(0),
+    oilPressureLevel(),
+    CANEvent(DEBOUNCE_TIME_MS),
+    colorEvent(DEBOUNCE_TIME_MS),
+    effectsEvent(DEBOUNCE_TIME_MS),
+    brightnessEvent(DEBOUNCE_TIME_MS),
+    CANPulseBegin(0)
+  { }
+
   // shortcut: construct directly from the pin states
-  SlaveState(PinStatus (*myDigitalRead)(pin_size_t), int (*myAnalogRead)(pin_size_t)) {
+  SlaveState(int (*myDigitalRead)(pin_size_t), int (*myAnalogRead)(pin_size_t)) :
+    SlaveState()
+  {
     setFromPins(myDigitalRead, myAnalogRead);
   }
 
-  // default constructor: anything goes. need to define this because
-  // the previous constructor definition prevents the implicit default
-  SlaveState() { }
+#ifdef PinStatus
+  // shortcut: construct directly from the pin states
+  SlaveState(PinStatus (*myDigitalRead)(pin_size_t), int (*myAnalogRead)(pin_size_t)) :
+    SlaveState()
+  {
+    setFromPins(myDigitalRead, myAnalogRead);
+  }
+#endif
+
+  // assignment operator
+  SlaveState& operator=(SlaveState const &s) {
+    backlightDim        = s.backlightDim;
+    tachometerCritical  = s.tachometerCritical;
+    ignition            = s.ignition;
+    fuelLevel           = s.fuelLevel;
+    temperatureLevel    = s.temperatureLevel;
+    oilPressureLevel    = s.oilPressureLevel;
+    masterMessage       = s.masterMessage;
+    CANPulseBegin       = s.CANPulseBegin;
+    effectmode          = s.effectmode;
+    return *this;
+  }
+
+  SlaveState(SlaveState const &s) :
+    SlaveState()
+  {
+    SlaveState::operator=(s);
+  }
+
 
 } SlaveState;

--- a/src/SlaveProperties.h
+++ b/src/SlaveProperties.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <Arduino.h>
-#include <Servo.h>
 #include "DashMessage.h"
 
 /**

--- a/src/SlaveProperties.h
+++ b/src/SlaveProperties.h
@@ -44,7 +44,7 @@ typedef struct SlaveState {
 
   DashMessage masterMessage;
 
-  // get a single bit from the master signals
+  // set the master signals
   inline void setMasterSignals(DashMessage const &m) {
     masterMessage = m;
   }

--- a/src/SlaveProperties.h
+++ b/src/SlaveProperties.h
@@ -73,7 +73,7 @@ typedef struct SlaveState {
   }
 
   // read payload from digital input pins into the fields of this struct
-  void setFromPins(int (*myDigitalRead)(pin_size_t), int (*myAnalogRead)(pin_size_t)) {
+  void setFromPins(PinStatus (*myDigitalRead)(pin_size_t), int (*myAnalogRead)(pin_size_t)) {
     scrollCAN          = myDigitalRead(SlavePin::Values::scrollCAN);
     backlightDim       = myDigitalRead(SlavePin::Values::backlightDim);
     tachometerCritical = myDigitalRead(SlavePin::Values::tachometerCritical);
@@ -102,7 +102,7 @@ typedef struct SlaveState {
   }
 
   // shortcut: construct directly from the pin states
-  SlaveState(int (*myDigitalRead)(pin_size_t), int (*myAnalogRead)(pin_size_t)) {
+  SlaveState(PinStatus (*myDigitalRead)(pin_size_t), int (*myAnalogRead)(pin_size_t)) {
     setFromPins(myDigitalRead, myAnalogRead);
   }
 

--- a/test/dash_state.cpp
+++ b/test/dash_state.cpp
@@ -1,0 +1,222 @@
+#include <ArduinoUnitTests.h>
+#include <Wire.h>
+
+#include "../src/DashMessage.h"
+#include "../src/DashState.h"
+
+
+// mock a FastLED object
+CFastLED FastLED;
+
+// mock the pin_size_t available on some boards
+#ifndef pin_size_t
+  typedef uint8_t pin_size_t;
+#endif
+
+int fakeDigitalRead(unsigned char pin) {
+  return digitalRead(pin);
+}
+
+void fakeDigitalWrite(pin_size_t pin, int val) {
+  return digitalWrite(pin, val);
+}
+
+// dummy dash support, dependency injection
+DashSupport ds = {
+  pinMode,
+  analogRead,
+  fakeDigitalRead,
+  fakeDigitalWrite,
+  &FastLED
+};
+
+// handle to godmode state so we can control inputs
+GodmodeState* state = GODMODE();
+DashState dash(ds);
+
+// reset the state before every test
+unittest_setup() {
+  state->reset();
+  dash.setup();
+}
+
+unittest(DashState_init)
+{
+  // show that dash setup() does in fact initialize everything
+  state->digitalPin[SlavePin::Values::ignitionInput]   = 0; // analog pin is read with digitalRead, so mock as such
+  assertEqual(0,    dash.bootStartTime);
+  assertEqual(0,    dash.ignitionLastOnTime);
+
+  // apply boot time should change the state
+  dash.apply(11);
+  assertEqual(11,   dash.bootStartTime);
+  assertEqual(0,    dash.ignitionLastOnTime);
+
+  // rerunning setup should change it back
+  dash.reset();
+  assertEqual(0,    dash.bootStartTime);
+  assertEqual(0,    dash.ignitionLastOnTime);
+}
+
+unittest(boot_time)
+{
+  // initial state is zeros
+  assertEqual(0,    dash.bootStartTime);
+  assertEqual(0,    dash.ignitionLastOnTime);
+
+  // check that the boot time comes on but not the ignition
+  state->digitalPin[SlavePin::Values::ignitionInput] = 0;
+  dash.setSlaveState(digitalRead, analogRead);
+  dash.apply(11);
+  assertEqual(11,   dash.bootStartTime);
+  assertEqual(0,    dash.ignitionLastOnTime);
+
+  // check that the ignition takes effect at the appropriate time
+  state->digitalPin[SlavePin::Values::ignitionInput] = 55;
+  dash.setSlaveState(digitalRead, analogRead);
+  dash.apply(22);
+  assertEqual(11,   dash.bootStartTime);
+  assertEqual(22,   dash.ignitionLastOnTime);
+
+}
+
+unittest(digital_raw_signals_to_state)
+{
+  for (int i = 0; i < 2; ++i) {
+    state->reset();
+    dash.setup();
+
+    DashMessage dm;
+    dm.setBit(MasterSignal::Values::boostWarning,         i);
+    dm.setBit(MasterSignal::Values::boostCritical,        i);
+    dm.setBit(MasterSignal::Values::acOn,                 i);
+    dm.setBit(MasterSignal::Values::heatedRearWindowOn,   i);
+    dm.setBit(MasterSignal::Values::hazardOff,            i);
+    dm.setBit(MasterSignal::Values::rearFoggerOn,         i);
+    dm.setBit(MasterSignal::Values::scrollCAN,            i);
+    dm.setBit(MasterSignal::Values::scrollPresetColours,  i);
+    dm.setBit(MasterSignal::Values::scrollRainbowEffects, i);
+    dm.setBit(MasterSignal::Values::scrollBrightness,     i);
+    dash.setMessage(dm);
+
+    state->digitalPin[SlavePin::Values::ignitionInput]      = 11;
+    state->digitalPin[SlavePin::Values::backlightDim]       = i;
+    state->digitalPin[SlavePin::Values::tachometerCritical] = i;
+    state->digitalPin[SlavePin::Values::tachometerWarning]  = i;
+
+    dash.setSlaveState(digitalRead, analogRead);
+
+    //assertEqual(i,    dash.state().scrollCAN);
+    assertEqual(i,    dash.state().backlightDim);
+    assertEqual(i,    dash.state().tachometerCritical);
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::boostWarning));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::boostCritical));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::acOn));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::heatedRearWindowOn));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::hazardOff));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::rearFoggerOn));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::scrollCAN));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::scrollPresetColours));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::scrollRainbowEffects));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::scrollBrightness));
+    assertEqual(i,    dash.state().effectmode.state);
+
+    dash.apply(35);
+
+    //assertEqual(i,    dash.state().scrollCAN);
+    assertEqual(i,    dash.state().backlightDim);
+    assertEqual(i,    dash.state().tachometerCritical);
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::boostWarning));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::boostCritical));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::acOn));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::heatedRearWindowOn));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::hazardOff));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::rearFoggerOn));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::scrollCAN));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::scrollPresetColours));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::scrollRainbowEffects));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::scrollBrightness));
+    assertEqual(i,    dash.state().effectmode.state);
+  }
+}
+
+unittest(digital_debounced_signals_to_state)
+{
+  for (int i = 0; i < 2; ++i) {
+    state->reset();
+    dash.setup();
+
+    DashMessage dm;
+    dm.setBit(MasterSignal::Values::boostWarning,         i);
+    dm.setBit(MasterSignal::Values::boostCritical,        i);
+    dm.setBit(MasterSignal::Values::acOn,                 i);
+    dm.setBit(MasterSignal::Values::heatedRearWindowOn,   i);
+    dm.setBit(MasterSignal::Values::hazardOff,            i);
+    dm.setBit(MasterSignal::Values::rearFoggerOn,         i);
+    dm.setBit(MasterSignal::Values::scrollCAN,            i);
+    dm.setBit(MasterSignal::Values::scrollPresetColours,  i);
+    dm.setBit(MasterSignal::Values::scrollRainbowEffects, i);
+    dm.setBit(MasterSignal::Values::scrollBrightness,     i);
+    dash.setMessage(dm);
+
+    state->digitalPin[SlavePin::Values::ignitionInput]      = 11;
+    state->digitalPin[SlavePin::Values::backlightDim]       = i;
+    state->digitalPin[SlavePin::Values::tachometerCritical] = i;
+    state->digitalPin[SlavePin::Values::tachometerWarning]  = i;
+
+    dash.setSlaveState(digitalRead, analogRead);
+
+    assertEqual(i,    dash.state().scrollCAN);
+    assertEqual(i,    dash.state().backlightDim);
+    assertEqual(i,    dash.state().tachometerCritical);
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::boostWarning));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::boostCritical));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::acOn));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::heatedRearWindowOn));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::hazardOff));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::rearFoggerOn));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::scrollCAN));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::scrollPresetColours));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::scrollRainbowEffects));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::scrollBrightness));
+    assertEqual(i,    dash.state().effectmode.state);
+
+    dash.apply(35);
+
+    assertEqual(i,    dash.state().scrollCAN);
+    assertEqual(i,    dash.state().backlightDim);
+    assertEqual(i,    dash.state().tachometerCritical);
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::boostWarning));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::boostCritical));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::acOn));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::heatedRearWindowOn));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::hazardOff));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::rearFoggerOn));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::scrollCAN));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::scrollPresetColours));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::scrollRainbowEffects));
+    assertEqual(i,    dash.state().masterMessage.getBit(MasterSignal::Values::scrollBrightness));
+    assertEqual(i,    dash.state().effectmode.state);
+  }
+}
+
+
+
+
+  // state->analogPin[1] = 99;
+  // assertEqual(99, analogRead(1));
+  // state->analogPin[1] = 56;
+  // assertEqual(56, analogRead(1));
+
+  // int future[6] = {33, 22, 55, 11, 44, 66};
+  // state->analogPin[1].fromArray(future, 6);
+  // for (int i = 0; i < 6; ++i)
+  // {
+  //   assertEqual(future[i], analogRead(1));
+  // }
+
+  // // assert end of history works
+  // assertEqual(future[5], analogRead(1));
+
+
+unittest_main()

--- a/test/debouncer.cpp
+++ b/test/debouncer.cpp
@@ -1,0 +1,90 @@
+#include <ArduinoUnitTests.h>
+#include "../src/Debouncer.h"
+
+unittest(debounce_stay_false)
+{
+  Debouncer d(3);
+
+  assertEqual(Debouncer::Event::none, d.eventOf(100, false));
+  assertEqual(Debouncer::Event::none, d.eventOf(101, false));
+  assertEqual(Debouncer::Event::none, d.eventOf(102, false));
+  assertEqual(Debouncer::Event::none, d.eventOf(103, false));
+  assertEqual(Debouncer::Event::none, d.eventOf(104, false));
+  assertEqual(Debouncer::Event::none, d.eventOf(105, false));
+}
+
+unittest(debounce_turn_true_fast_polling)
+{
+  Debouncer d1(3);
+
+  assertEqual(Debouncer::Event::none,   d1.eventOf(100, true));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(101, true));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(102, true));
+  assertEqual(Debouncer::Event::toHigh, d1.eventOf(103, true));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(104, true));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(114, true));
+}
+
+unittest(debounce_turn_true_slow_polling)
+{
+  Debouncer d1(3);
+
+  assertEqual(Debouncer::Event::none,   d1.eventOf(100, true));
+  assertEqual(Debouncer::Event::toHigh, d1.eventOf(110, true));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(111, true));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(121, true));
+}
+
+unittest(debounce_return_false_fast_polling)
+{
+  Debouncer d1(3);
+
+  assertEqual(Debouncer::Event::none,   d1.eventOf(100, true));
+  assertEqual(Debouncer::Event::toHigh, d1.eventOf(110, true));
+
+  assertEqual(Debouncer::Event::none,   d1.eventOf(200, false));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(201, false));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(202, false));
+  assertEqual(Debouncer::Event::toLow,  d1.eventOf(203, false));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(204, false));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(214, false));
+}
+
+unittest(debounce_return_false_slow_polling)
+{
+  Debouncer d1(3);
+  assertEqual(Debouncer::Event::none,   d1.eventOf(100, true));
+  assertEqual(Debouncer::Event::toHigh, d1.eventOf(110, true));
+
+  assertEqual(Debouncer::Event::none,   d1.eventOf(200, false));
+  assertEqual(Debouncer::Event::toLow,  d1.eventOf(210, false));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(211, false));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(221, false));
+}
+
+unittest(bouncing_true)
+{
+  Debouncer d1(3);
+  assertEqual(Debouncer::Event::none,   d1.eventOf(100, false));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(101, true));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(102, false));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(103, true));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(104, false));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(105, false));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(105, true));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(106, true));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(107, false));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(108, true));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(109, true));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(110, true));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(111, false));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(112, true));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(113, true));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(114, true));
+  assertEqual(Debouncer::Event::toHigh, d1.eventOf(115, true));
+  assertEqual(Debouncer::Event::none,   d1.eventOf(111, false));
+}
+
+
+
+unittest_main()

--- a/test/slave_state.cpp
+++ b/test/slave_state.cpp
@@ -1,0 +1,106 @@
+#include <ArduinoUnitTests.h>
+#include <Wire.h>
+
+#include "../src/SlaveProperties.h"
+
+// mock the pin_size_t available on some boards
+#ifndef pin_size_t
+  typedef uint8_t pin_size_t;
+#endif
+
+int fakeDigitalRead(unsigned char pin) {
+  return digitalRead(pin);
+}
+
+void fakeDigitalWrite(pin_size_t pin, int val) {
+  return digitalWrite(pin, val);
+}
+
+// handle to godmode state so we can control inputs
+GodmodeState* state = GODMODE();
+
+// reset the state before every test
+unittest_setup() {
+  state->reset();
+}
+
+unittest(SlaveState_assignment)
+{
+  // assert default values
+  SlaveState newstate;
+  assertEqual(0,    newstate.fuelLevel);
+  assertEqual(0,    newstate.temperatureLevel);
+  assertEqual(0,    newstate.oilPressureLevel);
+  assertEqual(0,    newstate.ignition);
+  assertEqual(EffectMode::Values::none, newstate.effectmode.state);
+
+  // assert that values can change
+  SlaveState astate;
+  astate.fuelLevel = 4;
+  astate.temperatureLevel = 3;
+  astate.oilPressureLevel = 2;
+  astate.ignition = 1;
+  astate.effectmode.state = EffectMode::Values::rainbow;
+  assertEqual(4,    astate.fuelLevel);
+  assertEqual(3,    astate.temperatureLevel);
+  assertEqual(2,    astate.oilPressureLevel);
+  assertEqual(1,    astate.ignition);
+  assertEqual(EffectMode::Values::rainbow, astate.effectmode.state);
+
+  // assert that assignment changes them back
+  astate = newstate;
+  assertEqual(0,    astate.fuelLevel);
+  assertEqual(0,    astate.temperatureLevel);
+  assertEqual(0,    astate.oilPressureLevel);
+  assertEqual(0,    astate.ignition);
+  assertEqual(EffectMode::Values::none, astate.effectmode.state);
+}
+
+unittest(SlaveState_analog_pins)
+{
+  // set some values on the analog pins
+  state->digitalPin[SlavePin::Values::ignitionInput]   = 11; // analog pin is read with digitalRead, so mock as such
+  state->analogPin[SlavePin::Values::fuelWarning]      = 22;
+  state->analogPin[SlavePin::Values::fuelInput]        = 33;
+  state->analogPin[SlavePin::Values::temperatureInput] = 44;
+  state->analogPin[SlavePin::Values::oilInput]         = 55;
+  state->analogPin[SlavePin::Values::scrollCAN]        = 66;
+
+  // read the values
+  SlaveState astate;
+  astate.setFromPins(digitalRead, analogRead);
+
+  // assert the values
+  assertEqual(33,   astate.fuelLevel);
+  assertEqual(44,   astate.temperatureLevel);
+  assertEqual(55,   astate.oilPressureLevel);
+  assertTrue(astate.ignition);
+}
+
+unittest(SlaveState_effectmode)
+{
+  SlaveState astate;
+  assertEqual(EffectMode::Values::none, astate.effectmode.state);
+}
+
+unittest(SlaveState_scrollCAN)
+{
+  SlaveState astate;
+  assertEqual(0, astate.CANPulseBegin);
+  assertEqual(false, astate.scrollCANstate(0));
+  assertEqual(false, astate.scrollCANstate(1));
+  assertEqual(false, astate.scrollCANstate(49));
+  assertEqual(false, astate.scrollCANstate(50));
+  assertEqual(false, astate.scrollCANstate(51));
+
+  astate.CANPulseBegin = 100;
+  assertEqual(100, astate.CANPulseBegin);
+  assertEqual(false, astate.scrollCANstate(99));
+  assertEqual(true, astate.scrollCANstate(100));
+  assertEqual(true, astate.scrollCANstate(101));
+  assertEqual(true, astate.scrollCANstate(149));
+  assertEqual(false, astate.scrollCANstate(150));
+  assertEqual(false, astate.scrollCANstate(151));
+}
+
+unittest_main()


### PR DESCRIPTION
* scrollCAN is now an output, as it was originally intended
* scrollCAN now pulses for 50ms (defined by a constant) 
* Various scroll inputs are debounced
* Fixed an issue where copying the state would reset the effects mode
* Implemented rainbow mode and "sparkle" party modes that should cycle on button press
* Compilation issues fixed